### PR TITLE
Add options "output" and "verbose"

### DIFF
--- a/tasks/regex_extract.js
+++ b/tasks/regex_extract.js
@@ -17,7 +17,9 @@ var options = this.options(
       regex : "(.*|\n*)",
 	  modifiers: "ig",
       matchPoints : "1",
-	  includePath : true
+	  includePath : true,
+	  verbose : true,
+	  output : ""
     });
 
     // For each [destination : source map] in list
@@ -55,21 +57,45 @@ var options = this.options(
 			matchstring += filepath;
 		  }
 		  
-		  matchPointsArray.forEach(function(current)
+		  if(options.output)
+		  {
+        // find all the occurances of regex groups using "$1" and "$2" syntax
+        var outputString = options.output.replace(/\$(\d+)/, function(numbers) {
+          var index = numbers.substring(1);
+          
+          if(match[index])
           {
-			if(!options.includePath && matchstring.length === 0)
-			{
-				matchstring += match[current].trim();
-			}
-			else
-			{
-				matchstring += ("," + match[current].trim());			
-			}
-          });
+            return match[index].trim();
+          }
+          else
+          {
+            return "";
+          }
+        });
+
+        matchstring += outputString;
+		  }
+		  else
+      {
+  		  matchPointsArray.forEach(function(current)
+            {
+  			if(!options.includePath && matchstring.length === 0)
+  			{
+  				matchstring += match[current].trim();
+  			}
+  			else
+  			{
+  				matchstring += ("," + match[current].trim());			
+  			}
+            });
+      }
           matches = matches + matchstring + "\n";
           matchstring = undefined;
         }
+    if(options.verbose)
+    {
 		grunt.log.writeln(matches);
+    }
         return matches;
       }).join("");
 


### PR DESCRIPTION
Verbose gives the user the ability to pass "false" to not see the output on their console
Output gives the user the ability to have complex replaces using typical dollar-sign grouping syntax such as:
"My $1 complex $3 output" rather than being limited to just comma separated responses
